### PR TITLE
fix: paragraph spacing for v0.12.0

### DIFF
--- a/expose.typ
+++ b/expose.typ
@@ -35,7 +35,9 @@
 
   v(2em)
 
-  show par: set block(spacing: 1em)
+  show par: set block(spacing: 1em) if sys.version <= version(0, 11, 1)
+  set par(spacing: 1em) if sys.version >= version(0, 12, 0)
+  
   set par(
     leading: 0.7em,
     justify: true,

--- a/template.typ
+++ b/template.typ
@@ -54,7 +54,9 @@
   show heading.where(level: 6) : small-heading()
   show heading.where(level: 7) : small-heading()
 
-  show par: set block(spacing: 1em) 
+  show par: set block(spacing: 1em) if sys.version <= version(0, 11, 1)
+  set par(spacing: 1em) if sys.version >= version(0, 12, 0)
+  
   set par(
     justify: true,
     leading: 1em, // Set the space between lines in text


### PR DESCRIPTION
This should fix incorrect paragraph spacing in v0.12.0 as `#show par: set block()` no longer works.
Also keeps backwards compatibility.