### PR TITLE
style: join advisors by newline instead of comma

### DIFF
--- a/titlepage.typ
+++ b/titlepage.typ
@@ -44,7 +44,7 @@
       Betreuer:
     ] else [
       Advisors:
-    ]), advisors.join(", "), strong(if (lang == "de") [
+    ]), advisors.join("\n"), strong(if (lang == "de") [
       Themensteller:
     ] else [
       Supervisor:


### PR DESCRIPTION
this looks a bit cleaner when joining multiple advisors imo
however, should still look bad for very long names and might break the layout for long lists of advisors

so what do you think?